### PR TITLE
Add basic test harness and associated build config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include config.mk
 
 .PHONY: options
-
+MAIN = ${OBJ_DIR}/driver.o
 SRC = $(wildcard ${SRC_DIR}/*.c)
 OBJ = $(patsubst ${SRC_DIR}/%.c,${OBJ_DIR}/%.o,${SRC})
 
@@ -18,11 +18,18 @@ options:
 ${NAME}: ${OBJ}
 	${CC} ${CFLAGS} $^ -o $@
 
+# The pipe is pretty cool
+${OBJ}: | ${OBJ_DIR}
+
 ${OBJ_DIR}:
 	mkdir $@
 
-${OBJ_DIR}/%.o: ${SRC_DIR}/%.c ${OBJ_DIR}
+${OBJ_DIR}/%.o: ${SRC_DIR}/%.c
 	${CC} -c ${CFLAGS} $< -o $@
+ 
+test: ${OBJ}
+	$(MAKE) -C test/ A_INCLUDE=../${INCLUDE} A_OBJ="$(patsubst %,../%,$(filter-out ${MAIN},${OBJ}))"
+A_LDFLAGS=${LDFLAGS}
 
 sdist:
 	mkdir -p ${NAME}-${VERSION}
@@ -30,6 +37,7 @@ sdist:
 	tar -cvzf ${NAME}-${VERSION}.tar.gz ${NAME}-${VERSION}
 
 clean:
+	$(MAKE) -C test/ clean
 	rm -rf ${OBJ_DIR} ${NAME}
 
 install: all

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,32 @@
+HTTPOSMS-SERVER(1)                             General Commands Manual                             HTTPOSMS-SERVER(1)
+
+NAME
+       httposms-server - HTTP tunnel over SMS server
+
+SYNOPSIS
+       httposms-server [OPTIONS]...  [DEVICE]
+
+DESCRIPTION
+       Using  the GPRS/GSM modem represented by DEVICE tunnel HTTP traffic over SMS from requests to the modem By de‐
+       fault the process will attempt to daemonize, and write its' output to the file "/tmp/httposms.log"
+
+OPTIONS
+       --version, -v
+              Print the package version and exit
+
+       --no-daemon, -n
+              Do not attempt to daemonize the process
+
+       --log-level, -l
+              The log severity [DEBUG, INFO, WARN, FAIL]
+
+       --device, -d
+              The device file for the GPRS/GSM module, defaults to "/dev/ttyAMA0"
+
+       --help, -h
+              Print this message and exit
+
+BUGS
+       Send all bug reports https://github.com/httposms/httposms-server
+
+                                          httposms-server-v0.0.0-prerelease                        HTTPOSMS-SERVER(1)

--- a/config.mk
+++ b/config.mk
@@ -4,7 +4,8 @@ NAME = httposms-server
 VERSION = v0.0.0-prerelease
 
 CC = gcc
-CFLAGS = -std=c99 -O2 -pedantic -Iinclude -Wall -DNAME="${NAME}" -DVERSION="${VERSION}"
+INCLUDE = include
+CFLAGS = -std=c99 -O2 -pedantic -I${INCLUDE} -Wall -DNAME="${NAME}" -DVERSION="${VERSION}"
 LDFLAGS= 
 
 SRC_DIR = src

--- a/docs/httposms-server.1
+++ b/docs/httposms-server.1
@@ -3,15 +3,31 @@
 httposms-server \- HTTP tunnel over SMS server
 .SH SYNOPSIS
 .B httposms-server
-.RB [ \-v ]
+[OPTIONS]...
+[DEVICE]
 .SH DESCRIPTION
-
-Placeholder, to be written
+Using the GPRS/GSM modem represented by DEVICE
+tunnel HTTP traffic over SMS from requests to the modem
+By default the process will attempt to daemonize, and write its'
+output to the file "/tmp/httposms.log"
 
 .SH OPTIONS
 .TP
-.B \-v
-Placeholder, to be written
+.B \-\-version, \-v
+Print the package version and exit
+.TP
+.B \-\-no\-daemon, \-n
+Do not attempt to daemonize the process
+.TP
+.B \-\-log\-level, \-l
+The log severity [DEBUG, INFO, WARN, FAIL]
+.TP
+.B \-\-device, \-d
+The device file for the GPRS/GSM module, defaults to "/dev/ttyAMA0"
+.TP
+.B \-\-help, \-h
+Print this message and exit
+
 .SH BUGS
-Send all bug reports https://github.com/httposms/httposms-server.com
+Send all bug reports https://github.com/httposms/httposms-server
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,32 @@
+include config.mk
+
+SRC_DIR = src
+OBJ_DIR = obj
+SRC = $(wildcard ${SRC_DIR}/*.c)
+OBJ = $(patsubst ${SRC_DIR}/%.c,${OBJ_DIR}/%.o,${SRC})
+
+all: options ${EXEC}
+
+options:
+	@echo Test build options
+	@echo "CFLAGS     = ${CFLAGS}"
+	@echo "LDFLAGS    = ${LDFLAGS}"
+	@echo "CC         = ${CC}"
+	@echo "SRC        = ${SRC}"
+	@echo "OBJ        = ${OBJ}"
+	@echo "[TEST] OBJ = ${A_OBJ}"
+
+${EXEC}: ${A_OBJ} ${OBJ}	
+	${CC} ${CFLAGS} $^ -o $@ ${LDFLAGS}
+
+${OBJ}: | ${OBJ_DIR}
+
+${OBJ_DIR}:
+	mkdir $@
+
+${OBJ_DIR}/%.o: ${SRC_DIR}/%.c
+	${CC} -c ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+.PHONY: clean
+clean:
+	rm -rf ${EXEC} ${OBJ_DIR}

--- a/test/config.mk
+++ b/test/config.mk
@@ -1,0 +1,11 @@
+EXEC = tests
+
+CC = gcc
+INCLUDE = include
+CFLAGS = -std=c99 -O2 -pedantic -I${A_INCLUDE} -Wall
+LDFLAGS= -lcunit
+
+SRC_DIR = src
+OBJ_DIR = obj
+
+

--- a/test/src/driver.c
+++ b/test/src/driver.c
@@ -1,0 +1,6 @@
+#include <CUnit/CUnit.h>
+
+int main(void)
+{
+        return 0;
+}


### PR DESCRIPTION
Add a basic test harness and readme file generated from the man page, should probably add application dependencies when there is some.